### PR TITLE
Handle controller hotplugging and unplug events

### DIFF
--- a/src/Networking/UnixConnection.py
+++ b/src/Networking/UnixConnection.py
@@ -12,6 +12,7 @@ class UnixConnection():
         self.connecting = False
         self.running = True
         self.connected = False
+        self.enabled = False
         self.lastHeartBeatTime = 0
         self.receiveThread = None
 
@@ -63,6 +64,9 @@ class UnixConnection():
             if (int(time() * 1000) - self.lastHeartBeatTime > 500 and self.connected):
                 ConsoleOutput.log("Disconnected")
                 self.connected = False
+                # Drop the enabled latch on disconnect so a reconnect requires
+                # an explicit Enable before the rover can move again.
+                self.enabled = False
                 self.connectCallback(False)
     
     def addPacketCallback(self, callback):
@@ -74,10 +78,15 @@ class UnixConnection():
             # ConsoleOutput.log(f'[{cmdName}] {json.dumps(data)};')
 
     def enable(self):
+        self.enabled = True
         self.sendCommand('enable', {})
         ConsoleOutput.log(f"Enabling")
-    
+
     def disable(self):
+        self.enabled = False
+        # Explicitly zero the drive command so the robot's stored motor state
+        # cannot keep the rover moving after a disable.
+        self.cmdDrive(0.0, 0.0)
         self.sendCommand('disable', {})
         ConsoleOutput.log(f"Disabling")
 

--- a/src/UI/MainApp.py
+++ b/src/UI/MainApp.py
@@ -214,29 +214,29 @@ class EnableFrame(customtkinter.CTkFrame):
         BOLD = customtkinter.CTkFont(weight="bold")
         self.master = master  
 
-        self.enableBtn = customtkinter.CTkButton(
+        # Single toggle: exactly one of Disabled/Enabled is active at a time and
+        # the selected segment is highlighted to show the current state.
+        self.stateToggle = customtkinter.CTkSegmentedButton(
             master=self,
-            text="Enable",
+            values=["Disabled", "Enabled"],
             font=BOLD,
-            width=150,
             height=40,
-            command=self.onEnable,
-            fg_color="green",
-            hover_color="darkgreen",
+            command=self.onToggle,
         )
-        self.enableBtn.grid(row=0, column=0, sticky="ew", padx=PAD, pady=0)
+        self.stateToggle.set("Disabled")
+        self.stateToggle.grid(row=0, column=0, sticky="ew", padx=PAD, pady=0)
+        self.lastEnabled = False
+        self.applyToggleColor(False)
 
-        self.disableBtn = customtkinter.CTkButton(
-            master=self,
-            text="Disable",
-            font=BOLD,
-            width=150,
-            height=40,
-            command=self.onDisable,
-            fg_color="red",
-            hover_color="darkred",
-        )
-        self.disableBtn.grid(row=0, column=1, sticky="ew", padx=PAD, pady=0)
+        # The enabled state can also change from controller events, tab switches
+        # and disconnects, so poll it and keep the toggle in sync.
+        self.syncToggle()
+
+    def onToggle(self, value):
+        if value == "Enabled":
+            self.onEnable()
+        else:
+            self.onDisable()
 
     def onEnable(self):
         # Go to Teleop tab in HomeTabView
@@ -249,6 +249,25 @@ class EnableFrame(customtkinter.CTkFrame):
         UnixConnection.networking.setController("disabled")
         UnixConnection.networking.disable()
         self.master.master.tab_view.set("Disabled")
+
+    def applyToggleColor(self, enabled):
+        self.stateToggle.configure(
+            selected_color="green" if enabled else "red",
+            selected_hover_color="darkgreen" if enabled else "darkred",
+        )
+
+    def syncToggle(self):
+        enabled = UnixConnection.networking.enabled
+        desired = "Enabled" if enabled else "Disabled"
+        if self.stateToggle.get() != desired:
+            # set() updates the selection without re-firing onToggle.
+            self.stateToggle.set(desired)
+        # Recolor whenever the state changes, including when the user clicks the
+        # toggle directly (selection already matches, so the check above is skipped).
+        if enabled != self.lastEnabled:
+            self.applyToggleColor(enabled)
+            self.lastEnabled = enabled
+        self.after(150, self.syncToggle)
 
         
 class TelemetryFrame(customtkinter.CTkFrame):

--- a/src/UI/TeleopUI.py
+++ b/src/UI/TeleopUI.py
@@ -63,6 +63,8 @@ class TeleopUI:
         self.cmdThread = threading.Thread(target=self.command, daemon=True)
         self.cmdThread.start()
 
+
+
     def command(self):
         lastScan = 0.0
         while True:
@@ -78,6 +80,7 @@ class TeleopUI:
             if self.controller and self.ctrlMode != CtrlMode.KEYBOARD:
                 try:
                     # Axis mapping for Logitech F310 (adjust if needed)
+                    # TODO: If ctrlmode is changed while controller is connected, disable for the first time before running again. Need a variable in uchariot-base to save to and adjust accordingly.
                     left_x = self.controller.get_axis(0)   # Left stick X
                     left_y = self.controller.get_axis(1)   # Left stick Y
                     right_x = self.controller.get_axis(2)  # Right stick X
@@ -89,7 +92,9 @@ class TeleopUI:
                     self.updateLabel()
                 except pygame.error:
                     # Controller was unplugged mid-read; drop it and stop driving.
+                    # TODO: This does not work as intended and should just disable the robot while controller is being switched
                     self.refreshController()
+                    UnixConnection.networking.setController('disabled')
                     self.vel = 0.0
                     self.rot = 0.0
                     self.updateLabel()

--- a/src/UI/TeleopUI.py
+++ b/src/UI/TeleopUI.py
@@ -14,7 +14,13 @@ class CtrlMode(Enum):
     ONE_STICK = "One Stick"
     TWO_STICK = "Two Stick"
     KEYBOARD = "Keyboard"
-    
+    # used to save control modes between controller disconnects,
+    # _currentCtrlMode = None
+    # def getCtrlMode():
+    #     return _currentCtrlMode
+    # def changeCtrlMode(newMode):
+    #     _currentCtrlMode = newMode
+
 PAD = 10
 
 class TeleopUI:
@@ -38,6 +44,7 @@ class TeleopUI:
 
         self.controllerLabel.grid(row=0, column=0, padx=PAD, pady=PAD, sticky="n")
         self.ctrlMode = CtrlMode.TWO_STICK
+        # CtrlMode.changeCtrlMode(CtrlMode.TWO_STICK)
 
         self.ctrlModeBtn = customtkinter.CTkButton(
             master=p_tab, text=self.ctrlMode.value, command=self.toggleCtrlMode
@@ -80,7 +87,6 @@ class TeleopUI:
             if self.controller and self.ctrlMode != CtrlMode.KEYBOARD:
                 try:
                     # Axis mapping for Logitech F310 (adjust if needed)
-                    # TODO: If ctrlmode is changed while controller is connected, disable for the first time before running again. Need a variable in uchariot-base to save to and adjust accordingly.
                     left_x = self.controller.get_axis(0)   # Left stick X
                     left_y = self.controller.get_axis(1)   # Left stick Y
                     right_x = self.controller.get_axis(2)  # Right stick X
@@ -94,10 +100,10 @@ class TeleopUI:
                     # Controller was unplugged mid-read; drop it and stop driving.
                     # TODO: This does not work as intended and should just disable the robot while controller is being switched
                     self.refreshController()
-                    UnixConnection.networking.setController('disabled')
                     self.vel = 0.0
                     self.rot = 0.0
                     self.updateLabel()
+                    UnixConnection.networking.disable()
             UnixConnection.networking.cmdDrive(self.vel, self.rot)
             if ConsoleOutput.closing:
                 break
@@ -124,10 +130,14 @@ class TeleopUI:
     def toggleCtrlMode(self):
         if self.ctrlMode == CtrlMode.ONE_STICK:
             self.ctrlMode = CtrlMode.TWO_STICK
+            # CtrlMode.changeCtrlMode(CtrlMode.TWO_STICK)
         elif self.ctrlMode == CtrlMode.TWO_STICK:
             self.ctrlMode = CtrlMode.KEYBOARD
+            # CtrlMode.changeCtrlMode(CtrlMode.KEYBOARD)
         else:
             self.ctrlMode = CtrlMode.ONE_STICK
+            # CtrlMode.changeCtrlMode(CtrlMode.ONE_STICK)
+        UnixConnection.networking.disable()
         self.ctrlModeBtn.configure(text=self.ctrlMode.value)
 
     def updateLabel(self):

--- a/src/UI/TeleopUI.py
+++ b/src/UI/TeleopUI.py
@@ -64,23 +64,57 @@ class TeleopUI:
         self.cmdThread.start()
 
     def command(self):
+        lastScan = 0.0
         while True:
+            pygame.event.pump()  # Process device add/remove + controller state
+
+            # Periodically (~1 Hz) re-scan for controllers so one plugged in
+            # after startup is detected and one unplugged is dropped.
+            now = time.time()
+            if now - lastScan > 1.0:
+                self.refreshController()
+                lastScan = now
+
             if self.controller and self.ctrlMode != CtrlMode.KEYBOARD:
-                pygame.event.pump()  # Update controller state
-                # Axis mapping for Logitech F310 (adjust if needed)
-                left_x = self.controller.get_axis(0)   # Left stick X
-                left_y = self.controller.get_axis(1)   # Left stick Y
-                right_x = self.controller.get_axis(2)  # Right stick X
-                self.vel = -left_y  # Invert Y axis for forward
-                if self.ctrlMode == CtrlMode.ONE_STICK:
-                    self.rot = left_x
-                else:
-                    self.rot = right_x
-                self.updateLabel()
+                try:
+                    # Axis mapping for Logitech F310 (adjust if needed)
+                    left_x = self.controller.get_axis(0)   # Left stick X
+                    left_y = self.controller.get_axis(1)   # Left stick Y
+                    right_x = self.controller.get_axis(2)  # Right stick X
+                    self.vel = -left_y  # Invert Y axis for forward
+                    if self.ctrlMode == CtrlMode.ONE_STICK:
+                        self.rot = left_x
+                    else:
+                        self.rot = right_x
+                    self.updateLabel()
+                except pygame.error:
+                    # Controller was unplugged mid-read; drop it and stop driving.
+                    self.refreshController()
+                    self.vel = 0.0
+                    self.rot = 0.0
+                    self.updateLabel()
             UnixConnection.networking.cmdDrive(self.vel, self.rot)
             if ConsoleOutput.closing:
                 break
             time.sleep(0.02)
+
+    def refreshController(self):
+        """Reconcile self.controller with the currently connected joysticks."""
+        count = pygame.joystick.get_count()
+        if count > 0 and self.controller is None:
+            self.controller = pygame.joystick.Joystick(0)
+            self.setControllerStatus(True)
+        elif count == 0 and self.controller is not None:
+            self.controller = None
+            self.setControllerStatus(False)
+
+    def setControllerStatus(self, connected):
+        text = "Controller Connected" if connected else "Controller Disconnected"
+        color = "green" if connected else "red"
+        # Marshal the widget update back onto the main (tkinter) thread.
+        self.controllerLabel.after(
+            0, lambda: self.controllerLabel.configure(text=text, text_color=color)
+        )
 
     def toggleCtrlMode(self):
         if self.ctrlMode == CtrlMode.ONE_STICK:

--- a/src/UI/TeleopUI.py
+++ b/src/UI/TeleopUI.py
@@ -32,10 +32,13 @@ class TeleopUI:
         pygame.init()
         pygame.joystick.init()
         self.controller = None
+        # SDL instance id of the controller we're currently bound to, used to
+        # detect when a controller is swapped for a different one at runtime.
+        self.activeInstanceId = None
 
         if pygame.joystick.get_count() > 0:
             self.controller = pygame.joystick.Joystick(0)
-            # self.controller.init()
+            self.activeInstanceId = self.controller.get_instance_id()
         self.controllerLabel = customtkinter.CTkLabel(
             p_tab,
             text="Controller Connected" if self.controller else "Controller Disconnected",
@@ -77,14 +80,23 @@ class TeleopUI:
         while True:
             pygame.event.pump()  # Process device add/remove + controller state
 
-            # Periodically (~1 Hz) re-scan for controllers so one plugged in
-            # after startup is detected and one unplugged is dropped.
+            # Periodically (~2 Hz) re-scan for controllers so one plugged in,
+            # unplugged, or swapped at runtime is detected.
             now = time.time()
-            if now - lastScan > 1.0:
+            if now - lastScan > 0.5:
                 self.refreshController()
                 lastScan = now
 
-            if self.controller and self.ctrlMode != CtrlMode.KEYBOARD:
+            enabled = UnixConnection.networking.enabled
+
+            if not enabled:
+                # Robot disabled: never command motion. Sending zeros every loop
+                # guarantees a held stick / stale value can't keep the rover moving.
+                self.vel = 0.0
+                self.rot = 0.0
+            elif self.ctrlMode == CtrlMode.KEYBOARD:
+                pass  # vel/rot are driven by the keyboard handlers
+            elif self.controller is not None:
                 try:
                     # Axis mapping for Logitech F310 (adjust if needed)
                     left_x = self.controller.get_axis(0)   # Left stick X
@@ -95,29 +107,60 @@ class TeleopUI:
                         self.rot = left_x
                     else:
                         self.rot = right_x
-                    self.updateLabel()
                 except pygame.error:
-                    # Controller was unplugged mid-read; drop it and stop driving.
-                    # TODO: This does not work as intended and should just disable the robot while controller is being switched
-                    self.refreshController()
+                    # Controller vanished mid-read: stop, then let refresh disable.
                     self.vel = 0.0
                     self.rot = 0.0
-                    self.updateLabel()
-                    UnixConnection.networking.disable()
+                    self.refreshController()
+            else:
+                # Enabled in a controller mode but no controller present: stay put.
+                self.vel = 0.0
+                self.rot = 0.0
+
+            self.updateLabel()
             UnixConnection.networking.cmdDrive(self.vel, self.rot)
             if ConsoleOutput.closing:
                 break
             time.sleep(0.02)
 
     def refreshController(self):
-        """Reconcile self.controller with the currently connected joysticks."""
+        """Reconcile self.controller with the connected joysticks and fail safe.
+
+        On any disconnect or controller swap the robot is disabled, so the
+        operator must press Enable again before the (new) controller can drive.
+        """
         count = pygame.joystick.get_count()
-        if count > 0 and self.controller is None:
-            self.controller = pygame.joystick.Joystick(0)
+
+        if count == 0:
+            if self.controller is not None:
+                self.controller = None
+                self.activeInstanceId = None
+                self.setControllerStatus(False)
+                self.haltForSafety("Controller disconnected")
+            return
+
+        current = pygame.joystick.Joystick(0)
+        instanceId = current.get_instance_id()
+
+        if self.controller is None:
+            # A controller appeared after startup.
+            self.controller = current
+            self.activeInstanceId = instanceId
             self.setControllerStatus(True)
-        elif count == 0 and self.controller is not None:
-            self.controller = None
-            self.setControllerStatus(False)
+            self.haltForSafety("Controller connected")
+        elif instanceId != self.activeInstanceId:
+            # A different controller was swapped in.
+            self.controller = current
+            self.activeInstanceId = instanceId
+            self.setControllerStatus(True)
+            self.haltForSafety("Controller changed")
+
+    def haltForSafety(self, reason):
+        """Zero the command and disable the robot after a controller event."""
+        self.vel = 0.0
+        self.rot = 0.0
+        ConsoleOutput.log(f"{reason}: disabling robot, press Enable to resume")
+        UnixConnection.networking.disable()
 
     def setControllerStatus(self, connected):
         text = "Controller Connected" if connected else "Controller Disconnected"
@@ -144,22 +187,28 @@ class TeleopUI:
         self.cmdVelValue.configure(text=f"{self.vel:.2f}")
         self.cmdRotValue.configure(text=f"{self.rot:.2f}")
 
+    def keyboardActive(self):
+        return (
+            self.ctrlMode == CtrlMode.KEYBOARD
+            and UnixConnection.networking.enabled
+        )
+
     def forwardKeyHandler(self, state):
-        if not self.ctrlMode == CtrlMode.KEYBOARD: return
+        if not self.keyboardActive(): return
         self.vel = 0.5 if state else 0.0
         self.updateLabel()
 
     def backwardKeyHandler(self, state):
-        if not self.ctrlMode == CtrlMode.KEYBOARD: return
+        if not self.keyboardActive(): return
         self.vel = -2.0 if state else 0.0
         self.updateLabel()
 
     def leftKeyHandler(self, state):
-        if not self.ctrlMode == CtrlMode.KEYBOARD: return
+        if not self.keyboardActive(): return
         self.rot = -1.0 if state else 0.0
         self.updateLabel()
-        
+
     def rightKeyHandler(self, state):
-        if not self.ctrlMode == CtrlMode.KEYBOARD: return
+        if not self.keyboardActive(): return
         self.rot = 1.0 if state else 0.0
         self.updateLabel()


### PR DESCRIPTION
Periodically rescans joysticks (~1 Hz) and processes pygame events so controllers plugged in after startup are detected and unplugged controllers are dropped. 